### PR TITLE
Add timezone selection with optional GPS detection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,5 +48,6 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     implementation("com.lyft.kronos:kronos-android:0.0.1-alpha11")
     implementation("androidx.compose.ui:ui-graphics")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest package="com.example.kronosanalogclock" xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application
         android:name=".KronosApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/kronosclock/AnalogClock.kt
+++ b/app/src/main/java/com/example/kronosclock/AnalogClock.kt
@@ -14,11 +14,14 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import kotlinx.coroutines.delay
 import kotlin.math.*
+import java.time.Instant
+import java.time.ZoneId
 
 @Composable
 fun AnalogClock(
     modifier: Modifier = Modifier,
     timeSourceMs: () -> Long,
+    zoneId: ZoneId,
     showNumerals: Boolean,
     ambientMode: Boolean,
     accentColor: Color
@@ -67,10 +70,10 @@ fun AnalogClock(
         if (showNumerals) drawNumerals(cx, cy, radius * 0.74f, onBg)
 
         val ms = nowMs.longValue
-        val totalSeconds = (ms % 60_000L).toFloat() / 1000f
-        val seconds = totalSeconds % 60f
-        val minutes = ((ms / 1000 / 60) % 60).toFloat() + (seconds / 60f)
-        val hours = ((ms / 1000 / 60 / 60) % 12).toFloat() + (minutes / 60f)
+        val zoned = Instant.ofEpochMilli(ms).atZone(zoneId)
+        val seconds = zoned.second.toFloat() + zoned.nano / 1_000_000_000f
+        val minutes = zoned.minute.toFloat() + seconds / 60f
+        val hours = (zoned.hour % 12).toFloat() + minutes / 60f
 
         val hourLen = radius * 0.55f
         val minLen  = radius * 0.75f

--- a/app/src/main/java/com/example/kronosclock/MainActivity.kt
+++ b/app/src/main/java/com/example/kronosclock/MainActivity.kt
@@ -2,16 +2,34 @@
 
 package com.example.kronosanalogclock
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Geocoder
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.example.kronosanalogclock.ui.theme.KronosClockTheme
+import com.google.android.gms.location.LocationServices
 import com.lyft.kronos.KronosClock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.time.ZoneId
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.coroutines.resume
 
 class MainActivity : ComponentActivity() {
     private val kronos: KronosClock by lazy { (application as KronosApp).kronos }
@@ -24,6 +42,17 @@ class MainActivity : ComponentActivity() {
             var ambient by remember { mutableStateOf(false) }
             var showNumerals by remember { mutableStateOf(true) }
             var accentSlot by remember { mutableStateOf(0) }
+            var zoneId by remember { mutableStateOf(ZoneId.systemDefault()) }
+
+            val context = LocalContext.current
+            val scope = rememberCoroutineScope()
+            val permissionLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) { granted ->
+                if (granted) {
+                    scope.launch { detectTimeZone(context)?.let { zoneId = it } }
+                }
+            }
 
             KronosClockTheme(darkTheme = darkTheme, useDynamicColor = dynamicColor) {
                 Scaffold(
@@ -92,11 +121,30 @@ class MainActivity : ComponentActivity() {
                             else -> scheme.primary
                         }
 
+                        TimeZoneSelector(
+                            zoneId = zoneId,
+                            onZoneChange = { zoneId = it },
+                            onDetect = {
+                                if (ContextCompat.checkSelfPermission(
+                                        context,
+                                        Manifest.permission.ACCESS_FINE_LOCATION
+                                    ) == PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    scope.launch {
+                                        detectTimeZone(context)?.let { zoneId = it }
+                                    }
+                                } else {
+                                    permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                                }
+                            }
+                        )
+
                         AnalogClock(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .weight(1f),
                             timeSourceMs = timeSource,
+                            zoneId = zoneId,
                             showNumerals = showNumerals,
                             ambientMode = ambient,
                             accentColor = accent
@@ -106,4 +154,57 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+}
+
+@Composable
+private fun TimeZoneSelector(
+    zoneId: ZoneId,
+    onZoneChange: (ZoneId) -> Unit,
+    onDetect: () -> Unit
+) {
+    val zones = remember { TimeZone.getAvailableIDs().sorted() }
+    var expanded by remember { mutableStateOf(false) }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+            OutlinedTextField(
+                readOnly = true,
+                value = zoneId.id,
+                onValueChange = {},
+                label = { Text("Timezone") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                modifier = Modifier.menuAnchor()
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                zones.forEach { id ->
+                    DropdownMenuItem(
+                        text = { Text(id) },
+                        onClick = {
+                            onZoneChange(ZoneId.of(id))
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+        Button(onClick = onDetect) { Text("Detect via GPS") }
+    }
+}
+
+@SuppressLint("MissingPermission")
+private suspend fun detectTimeZone(context: Context): ZoneId? = withContext(Dispatchers.IO) {
+    val client = LocationServices.getFusedLocationProviderClient(context)
+    val location = suspendCancellableCoroutine<android.location.Location?> { cont ->
+        client.lastLocation
+            .addOnSuccessListener { cont.resume(it) }
+            .addOnFailureListener { cont.resume(null) }
+    }
+    location ?: return@withContext null
+    val geocoder = Geocoder(context, Locale.getDefault())
+    val address = try {
+        geocoder.getFromLocation(location.latitude, location.longitude, 1)?.firstOrNull()
+    } catch (_: Exception) {
+        null
+    }
+    val ids = address?.countryCode?.let { TimeZone.getAvailableIDs(it) }
+    return@withContext ids?.firstOrNull()?.let { ZoneId.of(it) }
 }


### PR DESCRIPTION
## Summary
- allow choosing a timezone manually or detecting it via GPS
- draw analog clock using the selected timezone
- enable location services dependency and permission

## Testing
- `./gradlew test --no-daemon` *(fails: To honour the JVM settings for this build a single-use Daemon process will be forked. Daemon will be stopped at the end of the build)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9ee23dc8327853147e654d09daa