### PR TITLE
Add watch capture skeleton with camera and database

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -48,5 +49,19 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     implementation("com.lyft.kronos:kronos-android:0.0.1-alpha11")
     implementation("androidx.compose.ui:ui-graphics")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
+
+    // CameraX for watch face capture
+    val cameraXVersion = "1.3.4"
+    implementation("androidx.camera:camera-core:$cameraXVersion")
+    implementation("androidx.camera:camera-camera2:$cameraXVersion")
+    implementation("androidx.camera:camera-lifecycle:$cameraXVersion")
+    implementation("androidx.camera:camera-view:1.3.0")
+
+    // Room database for tracking watches
+    val roomVersion = "2.6.1"
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+    kapt("androidx.room:room-compiler:$roomVersion")
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest package="com.example.kronosanalogclock" xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
     <application
         android:name=".KronosApp"
         android:allowBackup="true"
@@ -12,5 +14,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity android:name=".WatchCaptureActivity" />
     </application>
 </manifest>

--- a/app/src/main/java/com/example/kronosclock/AnalogClock.kt
+++ b/app/src/main/java/com/example/kronosclock/AnalogClock.kt
@@ -14,11 +14,14 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import kotlinx.coroutines.delay
 import kotlin.math.*
+import java.time.Instant
+import java.time.ZoneId
 
 @Composable
 fun AnalogClock(
     modifier: Modifier = Modifier,
     timeSourceMs: () -> Long,
+    zoneId: ZoneId,
     showNumerals: Boolean,
     ambientMode: Boolean,
     accentColor: Color
@@ -67,10 +70,10 @@ fun AnalogClock(
         if (showNumerals) drawNumerals(cx, cy, radius * 0.74f, onBg)
 
         val ms = nowMs.longValue
-        val totalSeconds = (ms % 60_000L).toFloat() / 1000f
-        val seconds = totalSeconds % 60f
-        val minutes = ((ms / 1000 / 60) % 60).toFloat() + (seconds / 60f)
-        val hours = ((ms / 1000 / 60 / 60) % 12).toFloat() + (minutes / 60f)
+        val zoned = Instant.ofEpochMilli(ms).atZone(zoneId)
+        val seconds = zoned.second.toFloat() + zoned.nano / 1_000_000_000f
+        val minutes = zoned.minute.toFloat() + seconds / 60f
+        val hours = (zoned.hour % 12).toFloat() + minutes / 60f
 
         val hourLen = radius * 0.55f
         val minLen  = radius * 0.75f

--- a/app/src/main/java/com/example/kronosclock/KronosApp.kt
+++ b/app/src/main/java/com/example/kronosclock/KronosApp.kt
@@ -3,10 +3,12 @@ package com.example.kronosanalogclock
 import android.app.Application
 import com.lyft.kronos.AndroidClockFactory
 import com.lyft.kronos.KronosClock
+import com.example.kronosanalogclock.data.WatchDatabase
 
 class KronosApp : Application() {
     lateinit var kronos: KronosClock
         private set
+    val database: WatchDatabase by lazy { WatchDatabase.getInstance(this) }
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/example/kronosclock/MainActivity.kt
+++ b/app/src/main/java/com/example/kronosclock/MainActivity.kt
@@ -2,16 +2,36 @@
 
 package com.example.kronosanalogclock
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.location.Geocoder
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.example.kronosanalogclock.ui.theme.KronosClockTheme
+import com.google.android.gms.location.LocationServices
 import com.lyft.kronos.KronosClock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.time.ZoneId
+import java.util.Locale
+import java.util.TimeZone as JavaTimeZone
+import android.icu.util.TimeZone as IcuTimeZone
+import kotlin.coroutines.resume
 
 class MainActivity : ComponentActivity() {
     private val kronos: KronosClock by lazy { (application as KronosApp).kronos }
@@ -24,6 +44,17 @@ class MainActivity : ComponentActivity() {
             var ambient by remember { mutableStateOf(false) }
             var showNumerals by remember { mutableStateOf(true) }
             var accentSlot by remember { mutableStateOf(0) }
+            var zoneId by remember { mutableStateOf(ZoneId.systemDefault()) }
+
+            val context = LocalContext.current
+            val scope = rememberCoroutineScope()
+            val permissionLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) { granted ->
+                if (granted) {
+                    scope.launch { detectTimeZone(context)?.let { zoneId = it } }
+                }
+            }
 
             KronosClockTheme(darkTheme = darkTheme, useDynamicColor = dynamicColor) {
                 Scaffold(
@@ -92,18 +123,96 @@ class MainActivity : ComponentActivity() {
                             else -> scheme.primary
                         }
 
+                        TimeZoneSelector(
+                            zoneId = zoneId,
+                            onZoneChange = { zoneId = it },
+                            onDetect = {
+                                if (ContextCompat.checkSelfPermission(
+                                        context,
+                                        Manifest.permission.ACCESS_FINE_LOCATION
+                                    ) == PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    scope.launch {
+                                        detectTimeZone(context)?.let { zoneId = it }
+                                    }
+                                } else {
+                                    permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                                }
+                            }
+                        )
+
                         AnalogClock(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .weight(1f),
                             timeSourceMs = timeSource,
+                            zoneId = zoneId,
                             showNumerals = showNumerals,
                             ambientMode = ambient,
                             accentColor = accent
                         )
+
+                        Button(onClick = {
+                            context.startActivity(Intent(context, WatchCaptureActivity::class.java))
+                        }) {
+                            Text("Track Watch")
+                        }
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun TimeZoneSelector(
+    zoneId: ZoneId,
+    onZoneChange: (ZoneId) -> Unit,
+    onDetect: () -> Unit
+) {
+    val zones = remember { JavaTimeZone.getAvailableIDs().sorted() }
+    var expanded by remember { mutableStateOf(false) }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+            OutlinedTextField(
+                readOnly = true,
+                value = zoneId.id,
+                onValueChange = {},
+                label = { Text("Timezone") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                modifier = Modifier.menuAnchor()
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                zones.forEach { id ->
+                    DropdownMenuItem(
+                        text = { Text(id) },
+                        onClick = {
+                            onZoneChange(ZoneId.of(id))
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+        Button(onClick = onDetect) { Text("Detect via GPS") }
+    }
+}
+
+@SuppressLint("MissingPermission")
+private suspend fun detectTimeZone(context: Context): ZoneId? = withContext(Dispatchers.IO) {
+    val client = LocationServices.getFusedLocationProviderClient(context)
+    val location = suspendCancellableCoroutine<android.location.Location?> { cont ->
+        client.lastLocation
+            .addOnSuccessListener { cont.resume(it) }
+            .addOnFailureListener { cont.resume(null) }
+    }
+    location ?: return@withContext null
+    val geocoder = Geocoder(context, Locale.getDefault())
+    val address = try {
+        geocoder.getFromLocation(location.latitude, location.longitude, 1)?.firstOrNull()
+    } catch (_: Exception) {
+        null
+    }
+    val ids = address?.countryCode?.let { IcuTimeZone.getAvailableIDs(country = it) }
+    return@withContext ids?.firstOrNull()?.let { ZoneId.of(it) }
 }

--- a/app/src/main/java/com/example/kronosclock/WatchCaptureActivity.kt
+++ b/app/src/main/java/com/example/kronosclock/WatchCaptureActivity.kt
@@ -1,0 +1,75 @@
+package com.example.kronosanalogclock
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.example.kronosanalogclock.data.Watch
+import kotlinx.coroutines.launch
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+class WatchCaptureActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            val context = LocalContext.current
+            val app = context.applicationContext as KronosApp
+            val db = app.database
+            val scope = rememberCoroutineScope()
+            var make by remember { mutableStateOf("") }
+            var model by remember { mutableStateOf("") }
+            val previewView = remember { PreviewView(context) }
+
+            LaunchedEffect(Unit) {
+                val cameraProvider = ProcessCameraProvider.getInstance(context).await(context)
+                val preview = Preview.Builder().build().also {
+                    it.setSurfaceProvider(previewView.surfaceProvider)
+                }
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(this@WatchCaptureActivity, CameraSelector.DEFAULT_BACK_CAMERA, preview)
+            }
+
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                AndroidView({ previewView }, modifier = Modifier.weight(1f))
+                OutlinedTextField(value = make, onValueChange = { make = it }, label = { Text("Make") })
+                OutlinedTextField(value = model, onValueChange = { model = it }, label = { Text("Model") })
+                Button(
+                    onClick = {
+                        scope.launch {
+                            db.watchDao().insert(Watch(make = make, model = model, lastSyncedEpochMs = System.currentTimeMillis()))
+                            finish()
+                        }
+                    },
+                    enabled = make.isNotBlank() && model.isNotBlank()
+                ) {
+                    Text("Set as Synced")
+                }
+            }
+        }
+    }
+}
+
+private suspend fun <T> ListenableFuture<T>.await(context: android.content.Context): T =
+    suspendCancellableCoroutine { cont ->
+        addListener({ cont.resume(get()) }, ContextCompat.getMainExecutor(context))
+    }

--- a/app/src/main/java/com/example/kronosclock/data/Watch.kt
+++ b/app/src/main/java/com/example/kronosclock/data/Watch.kt
@@ -1,0 +1,12 @@
+package com.example.kronosanalogclock.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "watches")
+data class Watch(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val make: String,
+    val model: String,
+    val lastSyncedEpochMs: Long? = null
+)

--- a/app/src/main/java/com/example/kronosclock/data/WatchDao.kt
+++ b/app/src/main/java/com/example/kronosclock/data/WatchDao.kt
@@ -1,0 +1,22 @@
+package com.example.kronosanalogclock.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface WatchDao {
+    @Insert
+    suspend fun insert(watch: Watch): Long
+
+    @Update
+    suspend fun update(watch: Watch)
+
+    @Query("SELECT * FROM watches WHERE id = :id")
+    suspend fun get(id: Long): Watch?
+
+    @Query("SELECT * FROM watches ORDER BY make, model")
+    fun getAll(): Flow<List<Watch>>
+}

--- a/app/src/main/java/com/example/kronosclock/data/WatchDatabase.kt
+++ b/app/src/main/java/com/example/kronosclock/data/WatchDatabase.kt
@@ -1,0 +1,24 @@
+package com.example.kronosanalogclock.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [Watch::class], version = 1)
+abstract class WatchDatabase : RoomDatabase() {
+    abstract fun watchDao(): WatchDao
+
+    companion object {
+        @Volatile private var INSTANCE: WatchDatabase? = null
+
+        fun getInstance(context: Context): WatchDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    WatchDatabase::class.java,
+                    "watch-db"
+                ).build().also { INSTANCE = it }
+            }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
     plugins {
         id("com.android.application") version "8.12.0"
         id("org.jetbrains.kotlin.android") version "1.9.24"
+        id("org.jetbrains.kotlin.kapt") version "1.9.24"
     }
 }
 


### PR DESCRIPTION
## Summary
- wire up CameraX and Room dependencies
- add watch capture activity to store make, model, and sync time
- persist watch info in a Room database and expose it via the application
- fix timezone detection by selecting ICU country overload

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9ee23dc8327853147e654d09daa