### PR TITLE
Add basic watch management screen

### DIFF
--- a/app/src/main/java/com/example/kronosclock/MainActivity.kt
+++ b/app/src/main/java/com/example/kronosclock/MainActivity.kt
@@ -108,10 +108,23 @@ private fun KronosClockApp() {
             Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(16.dp)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text("Kronos Clock", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
-            Spacer(Modifier.height(12.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = { showWatches = true }) { Text("Manage Watches") }
+                Button(onClick = {
+                    kronos.sync(); isSynced = true; lastSyncStatus = "Manual sync triggered"
+                }) { Text("Sync Now") }
+                Button(onClick = {
+                    fetchCityAndZone(context, fusedClient) { c, z ->
+                        city = c
+                        zoneId = z ?: ZoneId.systemDefault()
+                    }
+                }) { Text("Refresh Location") }
+            }
 
             ElevatedCard(Modifier.padding(end = 8.dp)) {
                 Column(Modifier.padding(16.dp)) {
@@ -126,34 +139,13 @@ private fun KronosClockApp() {
                 }
             }
 
-            Spacer(Modifier.height(16.dp))
-
             Card {
                 Column(Modifier.padding(16.dp)) {
                     Text("NTP Status", fontWeight = FontWeight.SemiBold)
                     Text(if (isSynced) "Sync in progress / using Kronos time when available" else "Not synced yet")
                     lastSyncStatus?.let { Text(it) }
-                    Spacer(Modifier.height(8.dp))
-                    Row {
-                        Button(onClick = {
-                            kronos.sync(); isSynced = true; lastSyncStatus = "Manual sync triggered"
-                        }) { Text("Sync Now") }
-
-                        Spacer(Modifier.width(12.dp))
-
-                        Button(onClick = {
-                            fetchCityAndZone(context, fusedClient) { c, z ->
-                                city = c
-                                zoneId = z ?: ZoneId.systemDefault()
-                            }
-                        }) { Text("Refresh Location") }
-                    }
                 }
             }
-
-            Spacer(Modifier.height(16.dp))
-
-            Button(onClick = { showWatches = true }) { Text("Manage Watches") }
         }
     }
 }

--- a/app/src/main/java/com/example/kronosclock/MainActivity.kt
+++ b/app/src/main/java/com/example/kronosclock/MainActivity.kt
@@ -4,6 +4,7 @@ package com.example.kronosclock
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Geocoder
 import android.os.Bundle
@@ -12,6 +13,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -20,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.example.kronosclock.ui.theme.KronosClockTheme
+import com.example.kronosclock.data.WatchDatabase
 import com.google.android.gms.location.LocationServices
 import com.lyft.kronos.KronosClock
 import kotlinx.coroutines.delay
@@ -40,6 +44,8 @@ private fun KronosClockApp() {
     val context = LocalContext.current
     val fusedClient = remember { LocationServices.getFusedLocationProviderClient(context) }
     val kronos: KronosClock = remember { KronosApp.kronosClock }
+    val watchDao = remember { WatchDatabase.getInstance(context).watchDao() }
+    var showWatches by remember { mutableStateOf(false) }
 
     var city by remember { mutableStateOf<String?>(null) }
     var zoneId by remember { mutableStateOf(ZoneId.systemDefault()) }
@@ -89,46 +95,65 @@ private fun KronosClockApp() {
     val dateFmt = remember { DateTimeFormatter.ofPattern("EEE, MMM d uuuu").withLocale(Locale.getDefault()) }
     val timeFmt = remember { DateTimeFormatter.ofPattern("hh:mm:ss a").withLocale(Locale.getDefault()) }
 
-    Column(Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Kronos Clock", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
-        Spacer(Modifier.height(12.dp))
+    if (showWatches) {
+        WatchListScreen(
+            watchDao = watchDao,
+            onCapture = {
+                context.startActivity(Intent(context, WatchCaptureActivity::class.java))
+            },
+            onBack = { showWatches = false }
+        )
+    } else {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            Text("Kronos Clock", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(12.dp))
 
-        ElevatedCard(Modifier.padding(end = 8.dp)) {
-            Column(Modifier.padding(16.dp)) {
-                Text("Date", fontWeight = FontWeight.SemiBold)
-                Text(dateFmt.withZone(zoneId).format(ntpNow))
-                Spacer(Modifier.height(12.dp))
-                Text("Time", fontWeight = FontWeight.SemiBold)
-                Text(timeFmt.withZone(zoneId).format(ntpNow), style = MaterialTheme.typography.displaySmall)
-                Spacer(Modifier.height(12.dp))
-                Row { Text("Zone: ", fontWeight = FontWeight.SemiBold); Text(zoneId.id) }
-                city?.let { Row { Text("City: ", fontWeight = FontWeight.SemiBold); Text(it) } }
-            }
-        }
-
-        Spacer(Modifier.height(16.dp))
-
-        Card {
-            Column(Modifier.padding(16.dp)) {
-                Text("NTP Status", fontWeight = FontWeight.SemiBold)
-                Text(if (isSynced) "Sync in progress / using Kronos time when available" else "Not synced yet")
-                lastSyncStatus?.let { Text(it) }
-                Spacer(Modifier.height(8.dp))
-                Row {
-                    Button(onClick = {
-                        kronos.sync(); isSynced = true; lastSyncStatus = "Manual sync triggered"
-                    }) { Text("Sync Now") }
-
-                    Spacer(Modifier.width(12.dp))
-
-                    Button(onClick = {
-                        fetchCityAndZone(context, fusedClient) { c, z ->
-                            city = c
-                            zoneId = z ?: ZoneId.systemDefault()
-                        }
-                    }) { Text("Refresh Location") }
+            ElevatedCard(Modifier.padding(end = 8.dp)) {
+                Column(Modifier.padding(16.dp)) {
+                    Text("Date", fontWeight = FontWeight.SemiBold)
+                    Text(dateFmt.withZone(zoneId).format(ntpNow))
+                    Spacer(Modifier.height(12.dp))
+                    Text("Time", fontWeight = FontWeight.SemiBold)
+                    Text(timeFmt.withZone(zoneId).format(ntpNow), style = MaterialTheme.typography.displaySmall)
+                    Spacer(Modifier.height(12.dp))
+                    Row { Text("Zone: ", fontWeight = FontWeight.SemiBold); Text(zoneId.id) }
+                    city?.let { Row { Text("City: ", fontWeight = FontWeight.SemiBold); Text(it) } }
                 }
             }
+
+            Spacer(Modifier.height(16.dp))
+
+            Card {
+                Column(Modifier.padding(16.dp)) {
+                    Text("NTP Status", fontWeight = FontWeight.SemiBold)
+                    Text(if (isSynced) "Sync in progress / using Kronos time when available" else "Not synced yet")
+                    lastSyncStatus?.let { Text(it) }
+                    Spacer(Modifier.height(8.dp))
+                    Row {
+                        Button(onClick = {
+                            kronos.sync(); isSynced = true; lastSyncStatus = "Manual sync triggered"
+                        }) { Text("Sync Now") }
+
+                        Spacer(Modifier.width(12.dp))
+
+                        Button(onClick = {
+                            fetchCityAndZone(context, fusedClient) { c, z ->
+                                city = c
+                                zoneId = z ?: ZoneId.systemDefault()
+                            }
+                        }) { Text("Refresh Location") }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(onClick = { showWatches = true }) { Text("Manage Watches") }
         }
     }
 }

--- a/app/src/main/java/com/example/kronosclock/WatchListScreen.kt
+++ b/app/src/main/java/com/example/kronosclock/WatchListScreen.kt
@@ -1,0 +1,66 @@
+package com.example.kronosclock
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.kronosclock.data.Watch
+import com.example.kronosclock.data.WatchDao
+import kotlinx.coroutines.launch
+
+@Composable
+fun WatchListScreen(
+    watchDao: WatchDao,
+    onCapture: () -> Unit,
+    onBack: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val watches by watchDao.getAll().collectAsState(initial = emptyList())
+    var make by remember { mutableStateOf("") }
+    var model by remember { mutableStateOf("") }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        TopAppBar(title = { Text("My Watches") }, navigationIcon = {
+            Button(onClick = onBack) { Text("Back") }
+        })
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(Modifier.weight(1f)) {
+            items(watches) { watch ->
+                Text("${'$'}{watch.make} ${'$'}{watch.model}")
+            }
+        }
+        OutlinedTextField(
+            value = make,
+            onValueChange = { make = it },
+            label = { Text("Make") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = model,
+            onValueChange = { model = it },
+            label = { Text("Model") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = {
+                if (make.isNotBlank() && model.isNotBlank()) {
+                    scope.launch {
+                        watchDao.insert(Watch(make = make, model = model))
+                        make = ""
+                        model = ""
+                    }
+                }
+            }) { Text("Add") }
+            Button(onClick = onCapture) { Text("Capture") }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `WatchListScreen` composable to list, add, and capture watches
- Integrate watch management navigation into `MainActivity`
- Enable scrolling on the main screen so the watch options are accessible on smaller displays

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf2e4e5788327b2dbb1c1ec057b9f